### PR TITLE
Sort collections and add community.windows

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -13,17 +13,29 @@ dependencies:
     ---
     collections:
       - name: amazon.aws
+        version: ">=7.0.0"
       - name: ansible.posix
+        version: ">=1.5.4"
       - name: ansible.windows
+        version: ">=2.2.0"
       - name: awx.awx
+        version: ">=23.5.0"
       - name: azure.azcollection
+        version: ">=1.19.0"
       - name: community.windows
+        version: ">=2.1.0"
       - name: community.vmware
+        version: ">=2.15.0"
       - name: kubernetes.core
+        version: ">=2.4.0"
       - name: google.cloud
+        version: ">=1.3.0"
       - name: openstack.cloud
+        version: ">=2.2.0"
       - name: ovirt.ovirt
+        version: ">=3.2.0"
       - name: theforeman.foreman
+        version: ">=3.15.0"
   system: |
     epel-release [platform:rpm]
     gcc [platform:rpm]

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -12,48 +12,49 @@ dependencies:
   galaxy: |
     ---
     collections:
-      - name: awx.awx
-      - name: azure.azcollection
       - name: amazon.aws
-      - name: theforeman.foreman
-      - name: google.cloud
-      - name: openstack.cloud
-      - name: community.vmware
-      - name: ovirt.ovirt
-      - name: kubernetes.core
       - name: ansible.posix
       - name: ansible.windows
+      - name: awx.awx
+      - name: azure.azcollection
+      - name: community.windows
+      - name: community.vmware
+      - name: kubernetes.core
+      - name: google.cloud
+      - name: openstack.cloud
+      - name: ovirt.ovirt
+      - name: theforeman.foreman
   system: |
-    git-core [platform:rpm]
+    epel-release [platform:rpm]
     gcc [platform:rpm]
     gcc-c++ [platform:rpm]
-    python3.9-devel [platform:rpm compile]
-    libcurl-devel [platform:rpm compile]
+    git-core [platform:rpm]
+    git-lfs [platform:rpm]
     krb5-devel [platform:rpm compile]
     krb5-workstation [platform:rpm]
-    subversion [platform:rpm]
-    subversion [platform:dpkg]
-    git-lfs [platform:rpm]
-    sshpass [platform:rpm]
-    rsync [platform:rpm]
-    epel-release [platform:rpm]
-    python-unversioned-command [platform:rpm]
-    unzip [platform:rpm]
+    libcurl-devel [platform:rpm compile]
     podman-remote [platform:rpm]
+    python3.9-devel [platform:rpm compile]
+    python-unversioned-command [platform:rpm]
+    rsync [platform:rpm]
+    sshpass [platform:rpm]
+    subversion [platform:dpkg]
+    subversion [platform:rpm]
+    unzip [platform:rpm]
   python: |
     git+https://github.com/ansible/ansible-sign
     ncclient
     paramiko
+    pexpect>=4.5
     pykerberos
     pyOpenSSL
     pypsrp[kerberos,credssp]
-    pywinrm[kerberos,credssp]
-    toml
-    pexpect>=4.5
     python-daemon
+    pywinrm[kerberos,credssp]
     pyyaml
-    six
     receptorctl
+    six
+    toml
 additional_build_steps:
   append_base:
     - RUN $PYCMD -m pip install -U pip


### PR DESCRIPTION
Sort the list of collections / packages to make it easier to read. 
Also add the community.windows collection.

We should also pin the collection versions to current or greater, as it will speed up the build process.
(Galaxy has no concept of "latest" so when versions aren't pinned, it checks literally every version for compatibility with every other version of every collection you want to install)