### PR TITLE
Multiple Upgrades

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -6,19 +6,19 @@ on:
     branches:
       - main
   schedule:
-    # build every 12 hours
-    - cron: '0 */12 * * *'
+    # build every 24 hours at an arbitrary time
+    - cron: '45 3 * * *'
 
 jobs:
   build_and_push_latest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Build and push latest tag from devel and on new commits
     steps:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,14 @@ on:
 
 jobs:
   podman:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Podman
     steps:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -30,14 +30,14 @@ jobs:
           tox -e podman
 
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Docker
     steps:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Release
     steps:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -29,10 +29,10 @@ jobs:
 
       - name: Apply latest tag
         run: |
-         docker tag ghcr.io/${{ github.repository_owner }}/ascender-ee:${{ github.event.release.tag_name }} ghcr.io/${{ github.repository_owner }}/ascender-ee:latest
+          docker tag ghcr.io/${{ github.repository_owner }}/ascender-ee:${{ github.event.release.tag_name }} ghcr.io/${{ github.repository_owner }}/ascender-ee:latest
 
       - name: Push images
         run: |
-         echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
-         docker push ghcr.io/${{ github.repository_owner }}/ascender-ee:${{ github.event.release.tag_name }}
-         docker push ghcr.io/${{ github.repository_owner }}/ascender-ee:latest
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+          docker push ghcr.io/${{ github.repository_owner }}/ascender-ee:${{ github.event.release.tag_name }}
+          docker push ghcr.io/${{ github.repository_owner }}/ascender-ee:latest

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -2,41 +2,54 @@
 version: 3
 images:
   base_image:
-    name: rockylinux:9
+    name: rockylinux:9-minimal
+options:
+  package_manager_path: /usr/bin/microdnf
 dependencies:
+  python_interpreter:
+    package_system: python3.11
   ansible_core:
-    # Require minimum of 2.15 to get ansible-inventory --limit option
-    package_pip: ansible-core>=2.15.0rc2,<2.16
+    # Avoid Ansible 2.17 and above as it dropped support for Python 3.6, so it will not work with dnf on EL8 or below machines
+    package_pip: ansible-core>=2.16.14,<2.17
   ansible_runner:
     package_pip: ansible-runner
   galaxy: |
     ---
     collections:
       - name: amazon.aws
-        version: ">=7.0.0"
+        version: "9.5.0"
       - name: ansible.posix
-        version: ">=1.5.4"
+        version: ">=2.0.0"
+      - name: ansible.utils
+        version: ">=6.0.0"
       - name: ansible.windows
-        version: ">=2.2.0"
+        version: ">=3.1.0"
       - name: awx.awx
-        version: ">=23.5.0"
+        version: "24.6.1"
       - name: azure.azcollection
-        version: ">=1.19.0"
+        version: ">=3.6.0"
+      - name: community.aws
+        version: "9.3.0"
+      - name: community.general
+        version: ">=11.0.0"
       - name: community.windows
-        version: ">=2.1.0"
+        version: ">=3.0.0"
       - name: community.vmware
-        version: ">=2.15.0"
+        version: "4.8.6"
       - name: kubernetes.core
-        version: ">=2.4.0"
+        version: ">=6.0.0"
+      - name: microsoft.ad
+        version: ">=1.9.1"
       - name: google.cloud
-        version: ">=1.3.0"
+        version: ">=1.6.0"
       - name: openstack.cloud
-        version: ">=2.2.0"
+        version: ">=2.4.1"
       - name: ovirt.ovirt
-        version: ">=3.2.0"
+        version: ">=3.2.1"
       - name: theforeman.foreman
-        version: ">=3.15.0"
+        version: ">=5.4.0"
   system: |
+    crypto-policies-scripts
     epel-release [platform:rpm]
     gcc [platform:rpm]
     gcc-c++ [platform:rpm]
@@ -46,16 +59,15 @@ dependencies:
     krb5-workstation [platform:rpm]
     libcurl-devel [platform:rpm compile]
     podman-remote [platform:rpm]
-    python3.9-devel [platform:rpm compile]
-    python-unversioned-command [platform:rpm]
-    rsync [platform:rpm]
+    python3.11-devel [platform:rpm compile]
+    python3.11-rpm [platform:rpm epel]
     sshpass [platform:rpm]
-    subversion [platform:dpkg]
     subversion [platform:rpm]
-    unzip [platform:rpm]
     sudo [platform:rpm]
+    unzip [platform:rpm]
   python: |
-    git+https://github.com/ansible/ansible-sign
+    ansible-sign
+    jmespath
     ncclient
     paramiko
     pexpect>=4.5
@@ -66,9 +78,14 @@ dependencies:
     pywinrm[kerberos,credssp]
     pyyaml
     receptorctl
+    requests-credssp
     six
     toml
-    boto3
+  exclude:
+    system:
+      - python3
+      - python3-devel
+      - python3-rpm
 additional_build_files:
   - src: sudoers
     dest: configs
@@ -84,3 +101,15 @@ additional_build_steps:
     - RUN mkdir -p /runner
     - RUN useradd -G wheel -M -u 1000 -d /runner ascender
     - RUN chown -R ascender:wheel /runner
+    # Symlink podman-remote to podman to allow podman to run Ascender jobs via receptor
+    - RUN ln -s /usr/bin/podman-remote /usr/bin/podman
+    # Update crypto policies to allow SHA1 for older servers (EL 7 & 8)
+    - RUN update-crypto-policies --set DEFAULT:SHA1
+    # Create user site-packages directory - Allowing lookup plugins to use modules installed via pip
+    - RUN mkdir -p $($PYCMD -m site --user-site | sed "s|$HOME|$(pwd)|")
+    - RUN chmod -R ug+rwx $($PYCMD -m site --user-site | sed "s|$HOME|$(pwd)|" | cut -d '/' -f1,2,3)
+    # SymLink `python` -> `python3.11` and `python3` -> `python3.11` and `pip3` -> `pip3.11`
+    - >-
+      RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+      && alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+      && alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.11 1

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ minversion = 1.6
 skipsdist = True
 
 [testenv]
-basepython = python3
+basepython = python3.11
 install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
 
@@ -14,7 +14,7 @@ allowlist_externals =
   podman
 commands =
   /bin/bash -c "podman rmi ghcr.io/ctrliq/ascender-ee:latest || true"
-  ansible-builder build -v3 -t ghcr.io/ctrliq/ascender-ee {posargs}
+  ansible-builder build -v3 --build-arg PYCMD=/usr/bin/python3.11 -t ghcr.io/ctrliq/ascender-ee {posargs}
 
 [testenv:docker]
 passenv = HOME,DOCKER_BUILDKIT
@@ -23,4 +23,4 @@ allowlist_externals =
   docker
 commands =
   /bin/bash -c "docker rmi ghcr.io/ctrliq/ascender-ee:latest || true"
-  ansible-builder build -v3 -t ghcr.io/ctrliq/ascender-ee {posargs} --container-runtime=docker
+  ansible-builder build -v3 --build-arg PYCMD=/usr/bin/python3.11 -t ghcr.io/ctrliq/ascender-ee {posargs} --container-runtime=docker


### PR DESCRIPTION
* Ubuntu 20.04 is deprecated and no longer available, use 24.04 instead to get builds working again
* Upgrade build and EE to use Python 3.11
* Swap to rocky 9 minimal. This prevents us from needing to install python3.9 at all. 
* Upgrade to Ansible 2.16 (2.15 & 2.16 are both EOL but 2.16 fixes a few security issues).  Avoid 2.17 at all costs until EL8 is EOL
* Pin collections to last version to support Ansible 2.16 to avoid unsupported warnings 
* Build every 24 hours instead of 12 and avoid running at midnight 
* Change Cryto Policies to allow connecting to older servers (EL 7 & 8). 
* Remove python dependencies already provided by a collection