### PR TITLE
Add old update-ca-trust

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -96,7 +96,6 @@ additional_build_files:
 additional_build_steps:
   append_base:
     - RUN $PYCMD -m pip install -U pip
-    - COPY --chmod=755 _build/files/update-ca-trust /usr/bin/update-ca-trust
   append_final:
     - COPY --from=quay.io/ansible/receptor:devel /usr/bin/receptor /usr/bin/receptor
     - RUN mkdir -p /var/run/receptor
@@ -119,3 +118,5 @@ additional_build_steps:
       && alternatives --install /usr/bin/python python /usr/bin/python3.11 1
       && alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.11 1
     - RUN microdnf update -y && microdnf clean all
+    - COPY --chmod=755 _build/files/update-ca-trust /usr/bin/update-ca-trust
+

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -91,9 +91,12 @@ dependencies:
 additional_build_files:
   - src: sudoers
     dest: configs
+  - src: files/update-ca-trust
+    dest: files
 additional_build_steps:
   append_base:
     - RUN $PYCMD -m pip install -U pip
+    - COPY --chmod=755 _build/files/update-ca-trust /usr/bin/update-ca-trust
   append_final:
     - COPY --from=quay.io/ansible/receptor:devel /usr/bin/receptor /usr/bin/receptor
     - RUN mkdir -p /var/run/receptor

--- a/files/update-ca-trust
+++ b/files/update-ca-trust
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+#set -vx
+
+# At this time, while this script is trivial, we ignore any parameters given.
+# However, for backwards compatibility reasons, future versions of this script must 
+# support the syntax "update-ca-trust extract" trigger the generation of output 
+# files in $DEST.
+
+DEST=/etc/pki/ca-trust/extracted
+
+# Prevent p11-kit from reading user configuration files.
+export P11_KIT_NO_USER_CONFIG=1
+
+# OpenSSL PEM bundle that includes trust flags
+# (BEGIN TRUSTED CERTIFICATE)
+/usr/bin/p11-kit extract --format=openssl-bundle --filter=certificates --overwrite --comment $DEST/openssl/ca-bundle.trust.crt
+/usr/bin/p11-kit extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose server-auth $DEST/pem/tls-ca-bundle.pem
+/usr/bin/p11-kit extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose email $DEST/pem/email-ca-bundle.pem
+/usr/bin/p11-kit extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose code-signing $DEST/pem/objsign-ca-bundle.pem
+/usr/bin/p11-kit extract --format=java-cacerts --filter=ca-anchors --overwrite --purpose server-auth $DEST/java/cacerts
+/usr/bin/p11-kit extract --format=edk2-cacerts --filter=ca-anchors --overwrite --purpose=server-auth $DEST/edk2/cacerts.bin


### PR DESCRIPTION
ca-certificates changed the update-ca-trust script, and the new one requires the addition of an --output command line argument.  This has been fixed in the awx-operator, but have to await a new version or fork it ourselves.

This works around the issue by bundling in the old script.