### PR TITLE
Change order in which DNF update runs

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -112,11 +112,11 @@ additional_build_steps:
     # Create user site-packages directory - Allowing lookup plugins to use modules installed via pip
     - RUN mkdir -p $($PYCMD -m site --user-site | sed "s|$HOME|$(pwd)|")
     - RUN chmod -R ug+rwx $($PYCMD -m site --user-site | sed "s|$HOME|$(pwd)|" | cut -d '/' -f1,2,3)
+    - RUN dnf update -y && dnf clean all
     # SymLink `python` -> `python3.11` and `python3` -> `python3.11` and `pip3` -> `pip3.11`
     - >-
       RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
       && alternatives --install /usr/bin/python python /usr/bin/python3.11 1
       && alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.11 1
-    - RUN dnf update -y && dnf clean all
     - COPY --chmod=755 _build/files/update-ca-trust /usr/bin/update-ca-trust
 


### PR DESCRIPTION
### Problem

`dnf update` was overwriting the alternatives-managed python3 symlink, causing it to point to python3.9 instead of python3.11.

### Solution

Move alternatives commands to run after `dnf update` so package updates can't overwrite the configuration.
