### PR TITLE
Pin GitHub Actions to SHAs [SRE-1802]

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-24.04
     name: Build and push latest tag from devel and on new commits
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
         with:
           python-version: "3.11"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-24.04
     name: Podman
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
         with:
           python-version: "3.11"
 
@@ -33,9 +33,9 @@ jobs:
     runs-on: ubuntu-24.04
     name: Docker
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
         with:
           python-version: "3.11"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-24.04
     name: Release
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## Summary
Pin GitHub Actions references in this repo to immutable commit SHAs (with the original tag/branch preserved in a trailing comment). Part of [SRE-1802](https://ciqinc.atlassian.net/browse/SRE-1802) — org-wide supply-chain hardening.

## Scope
This PR pins:
- Internal `ctrliq/*` reusable workflow and action references
- External actions **not** handled by clo-ciq's parallel Node 20 effort

_No actions in this repo were claimed by clo-ciq's effort — this PR pins everything._

## Files touched

- `.github/workflows/build-latest.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`

## Test plan
- [ ] Workflow runs succeed on this branch (or on next trigger after merge)
- [ ] Once this and any companion clo-ciq PR merge, this repo has zero unpinned external/internal refs and `sha_pinning_required` can be enabled on it

[SRE-1802]: https://ciqinc.atlassian.net/browse/SRE-1802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ